### PR TITLE
asort instead of ksort

### DIFF
--- a/plugins/mm/acadre.inc
+++ b/plugins/mm/acadre.inc
@@ -419,8 +419,8 @@ function _os2web_acadre_esdh_mm_order_addenums($drush = FALSE) {
   $debug && error_log('MM Import - Update addendums on ' . count($meetings) . ' nodes - ' . timer_read('_os2web_acadre_esdh_mm_order_addenums') . 'ms - ' . memory_get_usage());
   // Run through the meeting array, to determine the addendums.
   foreach ($meetings as $m_id => $meeting) {
-    // Lowest system id first.
-    ksort($meeting);
+    // Lowest node id first.
+    asort($meeting);
     if (in_array($m_id, $rev_meetings)) {
       $meeting = array_reverse($meeting);
     }


### PR DESCRIPTION
ksort will sort "meetings" by system id.
But if dagsorden is updated after addendum is added, update dagsorden has higher system-id and will become addendum.
Node id seems more correct.
Only error i can imagine, if user deletes dagsorden and re-import dagsorden. Addendum will have lowest node id.
